### PR TITLE
changed handler into an optional function parameters in focusin and focu...

### DIFF
--- a/jQuery/JQuery.hx
+++ b/jQuery/JQuery.hx
@@ -281,12 +281,12 @@ extern class JQuery implements ArrayAccess<Dom> {
 	/**
 		Bind an event handler to the "focusin" JavaScript event.
 	**/
-	public function focusin(?eventDataOrHandler:Dynamic, handler:Dynamic):JQuery;
+	public function focusin(?eventDataOrHandler:Dynamic, ?handler:Dynamic):JQuery;
 
 	/**
 		Bind an event handler to the "focusout" JavaScript event.
 	**/
-	public function focusout(?eventDataOrHandler:Dynamic, handler:Dynamic):JQuery;
+	public function focusout(?eventDataOrHandler:Dynamic, ?handler:Dynamic):JQuery;
 
 	/**
 		Retrieve the DOM elements matched by the jQuery object.


### PR DESCRIPTION
little change to the focusin and focusout functions, the handler is optional now

otherwise you need to type:

```
        new JQuery("#markdown_input").focusin( null, function( event ) {
             js.Lib.alert("Hello world!");
        });
```
